### PR TITLE
Update __main__.py

### DIFF
--- a/tools/RAiDER/cli/__main__.py
+++ b/tools/RAiDER/cli/__main__.py
@@ -31,7 +31,8 @@ def main() -> None:
 
     try:
         # python >=3.10 interface
-        (process_entry_point,) = entry_points(group='console_scripts', name=f'{args.process}.py')
+        process_entry_point = next(iter(entry_points(group='console_scripts', name=f'{args.process}.py')), None)
+
     except TypeError:
         # python 3.8 and 3.9 interface
         scripts = entry_points()['console_scripts']


### PR DESCRIPTION
# Fix ValueError in RAiDER CLI by adjusting entry_points unpacking in `__main__.py`

## Description
Modified the unpacking method in `RAiDER/cli/__main__.py` to address a `ValueError` that caused the `raider.py` CLI command to fail with a "too many values to unpack" error. This update ensures compatibility with the latest Python `importlib` behavior, preventing the unpacking issue.

## Motivation and Context
This change is required to prevent errors when running RAiDER CLI commands. The error was due to Python's `entry_points` returning multiple values, causing the unpacking in `__main__.py` to fail. This update aligns the code with Python's latest handling of `entry_points`.

*Link to any related issue (if applicable).*

## How Has This Been Tested?
- Ran `raider.py --help` and other CLI commands locally to verify that the error no longer appears.
- Ensured the modified unpacking works as expected without breaking other functionality.

*Include any specific testing steps or commands you used, if relevant.*

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have added an explanation of what my changes do and why I'd like them included.
- [ ] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
