### PR TITLE
Fix look direction assertion bug

### DIFF
--- a/tools/RAiDER/llreader.py
+++ b/tools/RAiDER/llreader.py
@@ -146,8 +146,8 @@ class AOI:
         except AttributeError:
             lookDir = lookDir.lower()
 
-        assert direction in 'asc desc'.split(), f'Incorrection orbital direction: {direction}. Choose asc or desc.'
-        assert lookDir in 'right light'.split(), f'Incorrection look direction: {lookDir}. Choose right or left.'
+        assert direction in 'asc desc'.split(), f'Incorrect orbital direction: {direction}. Choose asc or desc.'
+        assert lookDir in 'right left'.split(), f'Incorrect look direction: {lookDir}. Choose right or left.'
 
         S, N, W, E = self.bounds()
 


### PR DESCRIPTION
## Summary
- fix incorrect look direction options in `calc_buffer_ray`
- clarify error messages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846ad1e3e348320b3eae18da2b832bb