### PR TITLE
Fix reading of whitespace-separated station files

### DIFF
--- a/tools/RAiDER/gnss/downloadGNSSDelays.py
+++ b/tools/RAiDER/gnss/downloadGNSSDelays.py
@@ -54,7 +54,7 @@ def get_station_list(
                     if k == 0:
                         names = line.strip().split()
                     else:
-                        stations.append([line.strip().split()])
+                        stations.append(line.strip().split())
             station_data = pd.DataFrame(stations, columns=names)         
     else:
         station_data = get_stats_by_llh(llhBox=bbox)


### PR DESCRIPTION
## Summary
- correct building of station list when falling back to manual parsing

## Testing
- `pytest test/test_gnss.py::test_get_station_list -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846b4853bd083208ab3aec4606d83b3