### PR TITLE
Fix typos in comments

### DIFF
--- a/tools/RAiDER/cli/statsPlot.py
+++ b/tools/RAiDER/cli/statsPlot.py
@@ -729,7 +729,7 @@ class VariogramAnalysis:
         d_test_arr = []
         v_test_arr = []
         for j in sorted(list(set(grid_subset['Date']))):
-            # If insufficient sample size, skip slice and record occurence
+            # If insufficient sample size, skip slice and record occurrence
             if len(np.array(grid_subset[grid_subset['Date'] == j][self.col_name])) < self.densitythreshold:
                 # Record skipped [gridnode, timeslice]
                 self.skipped_slices.append([grid_ind, j.strftime('%Y-%m-%d')])

--- a/tools/RAiDER/s1_azimuth_timing.py
+++ b/tools/RAiDER/s1_azimuth_timing.py
@@ -271,7 +271,7 @@ def get_n_closest_datetimes(
         # In the event that t_floor == t_ceil for k = 0
         out_times = list(set([t_ceil, t_floor]))
         closest_times.extend(out_times)
-    # if 2 times have same distance to ref_time, order times by occurence (earlier comes first)
+    # if 2 times have same distance to ref_time, order times by occurrence (earlier comes first)
     closest_times = sorted(closest_times, key=lambda ts_rounded: (abs(ts - ts_rounded), ts_rounded))
     closest_times = [t.to_pydatetime() for t in closest_times]
     closest_times = closest_times[:n_target_times]


### PR DESCRIPTION
## Summary
- fix a comment typo in statsPlot.py
- fix a comment typo in s1_azimuth_timing.py

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846b482d6f08320a7df2167c78872a1